### PR TITLE
added autoload option

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,10 +11,10 @@ AllCops:
     - 'example/**/*'
 
 Metrics/AbcSize:
-  Max: 17
+  Max: 22
 
 Metrics/MethodLength:
-  Max: 14
+  Max: 20
 
 Metrics/BlockLength:
   Exclude:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ class YourModel
 end
 ```
 
-#### export: false
+#### export: false option ( default: true )
 
 :name method is just shorthand for bulk\_loader.public\_send(:name). So if you not want to create :name method, you can pass export: false to bulk\_loader definition.
 
@@ -98,6 +98,32 @@ then you can use this like followings.
 
 ```ruby
   YourModel.new.bulk_loader.name
+```
+
+#### autoload: false option ( default: true )
+
+If you set this option to false, +BulkLoader::UnloadAccessError+ occured when you does not call +YourModel.bulk\_loader.load explicitly on :name method.
+
+```ruby
+class YourModel
+  include BulkLoader::DSL
+
+  bulk_loader :name, :mapped_key, default: nil, autoload: false do |mapped_keys|
+    # something with mapped_keys
+  end
+end
+```
+
+```ruby
+  YourModel.new.name #=> raise error BulkLoader::UnloadAccessError
+```
+
+You can pass this by calling load explicitly.
+
+```ruby
+  model = YourModel.new
+  YourModel.bulk_loader.load(:name, [model])
+  model.name #=> it does not raise BulkLoader::UnloadAccessError
 ```
 
 ## Installation

--- a/lib/bulk_loader/attribute.rb
+++ b/lib/bulk_loader/attribute.rb
@@ -8,7 +8,7 @@ module BulkLoader
     end
 
     def lazy(name)
-      @lazy_of[name] ||= BulkLoader::Lazy.new(@target)
+      @lazy_of[name] ||= BulkLoader::Lazy.new(@target, name: name)
     end
 
     def loaded?(name)
@@ -39,7 +39,7 @@ module BulkLoader
       names = [name].freeze
       define_singleton_method(name) do
         attr = lazy(name)
-        class_attribute.load(names, [self]) unless attr.loaded?
+        class_attribute.load(names, [self]) if !attr.loaded? && class_attribute.autoload?(name)
         attr.get
       end
       public_send(name)

--- a/lib/bulk_loader/class_attribute.rb
+++ b/lib/bulk_loader/class_attribute.rb
@@ -6,10 +6,16 @@ module BulkLoader
   class ClassAttribute
     def initialize
       @loader_of = {}
+
+      @no_autoload_of = {}
     end
 
     def include?(name)
       @loader_of.include?(name)
+    end
+
+    def autoload?(name)
+      !@no_autoload_of[name]
     end
 
     def each(&block)
@@ -27,8 +33,9 @@ module BulkLoader
       end
     end
 
-    def define_loader(name, loader)
+    def define_loader(name, loader, autoload: true)
       @loader_of[name] = loader
+      @no_autoload_of[name] = true unless autoload
       define_singleton_method(name) { loader }
     end
 

--- a/lib/bulk_loader/dsl.rb
+++ b/lib/bulk_loader/dsl.rb
@@ -18,8 +18,11 @@ module BulkLoader
         name, mapping, options = *args
         options ||= {}
         does_export = options.delete(:export)
+        does_autoload = options.delete(:autoload)
+        does_autoload = true if does_autoload.nil?
 
-        @bulk_loader.define_loader(name, BulkLoader::Loader.new(mapping, options, &block))
+        loader = BulkLoader::Loader.new(mapping, options, &block)
+        @bulk_loader.define_loader(name, loader, autoload: does_autoload)
 
         return if does_export == false
 

--- a/lib/bulk_loader/lazy.rb
+++ b/lib/bulk_loader/lazy.rb
@@ -1,18 +1,21 @@
 # frozen_string_literal: true
 
 module BulkLoader
+  class UnloadAccessError < StandardError; end
+
   # lazy class
   class Lazy
     attr_reader :target
 
-    def initialize(target)
+    def initialize(target, name: nil)
       @loaded = false
       @value = nil
+      @name = name
       @target = target
     end
 
     def get
-      raise 'data is not loaded!!' unless @loaded
+      raise UnloadAccessError, "#{@name} has not been loaded!!" unless @loaded
 
       @value
     end

--- a/spec/bulk_loader/dsl_spec.rb
+++ b/spec/bulk_loader/dsl_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe BulkLoader::DSL do
   class Model
     include BulkLoader::DSL
 
-    bulk_loader :test, ->(i) { i } do
+    bulk_loader :test, :object_id do
       {}
     end
   end
 
   class ModelChild < Model
-    bulk_loader :test_child, ->(i) { i } do
+    bulk_loader :test_child, ->(i) { i }, autoload: false do
       {}
     end
   end
@@ -38,7 +38,7 @@ RSpec.describe BulkLoader::DSL do
 
   it { expect { model.test }.to_not raise_exception }
   it { expect { model_child.test }.to_not raise_exception }
-  it { expect { model_child.test_child }.to_not raise_exception }
+  it { expect { model_child.test_child }.to raise_error(BulkLoader::UnloadAccessError) }
 
   it do
     Model.bulk_loader.load(:test, [model.bulk_loader])

--- a/spec/bulk_loader/lazy_spec.rb
+++ b/spec/bulk_loader/lazy_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe BulkLoader::Lazy do
   describe '#set' do
     subject { -> { lazy.set(true) } }
-    let(:lazy) { described_class.new(nil) }
+    let(:lazy) { described_class.new(nil, name: :lazy) }
 
     it { is_expected.to change { lazy.loaded? }.to(true) }
   end
@@ -13,10 +13,10 @@ RSpec.describe BulkLoader::Lazy do
   describe '#get' do
     subject { -> { lazy.get } }
 
-    let(:lazy) { described_class.new(nil) }
+    let(:lazy) { described_class.new(nil, name: :lazy) }
 
     context 'when it was not set' do
-      it { is_expected.to raise_error(RuntimeError) }
+      it { is_expected.to raise_error(BulkLoader::UnloadAccessError) }
     end
 
     context 'wehn value was set' do
@@ -30,7 +30,7 @@ RSpec.describe BulkLoader::Lazy do
   end
 
   describe '#clear' do
-    let(:lazy) { described_class.new(nil) }
+    let(:lazy) { described_class.new(nil, name: :lazy) }
 
     subject { -> { lazy.clear } }
 

--- a/spec/bulk_loader/loader_spec.rb
+++ b/spec/bulk_loader/loader_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe BulkLoader::Loader do
     context 'when block result is not include lazy_obj target' do
       let(:block) { ->(_) { {} } }
 
-      let(:lazy_obj1) { BulkLoader::Lazy.new(1) }
-      let(:lazy_obj2) { BulkLoader::Lazy.new(1) }
+      let(:lazy_obj1) { BulkLoader::Lazy.new(1, name: :obj1) }
+      let(:lazy_obj2) { BulkLoader::Lazy.new(1, name: :obj2) }
 
       it { is_expected.to change { lazy_obj1.loaded? }.from(false).to(true) }
       it { is_expected.to change { lazy_obj2.loaded? }.from(false).to(true) }
@@ -22,8 +22,8 @@ RSpec.describe BulkLoader::Loader do
 
     context 'when block result is include lazy_obj target' do
       let(:block) { ->(_) { { 1 => true, 2 => false, 3 => true } } }
-      let(:lazy_obj1) { BulkLoader::Lazy.new(2) }
-      let(:lazy_obj2) { BulkLoader::Lazy.new(2) }
+      let(:lazy_obj1) { BulkLoader::Lazy.new(2, name: :obj1) }
+      let(:lazy_obj2) { BulkLoader::Lazy.new(2, name: :obj2) }
 
       it 'should set false to lazy_obj' do
         subject.call
@@ -35,8 +35,8 @@ RSpec.describe BulkLoader::Loader do
     context 'when lazy_obj has already loaded' do
       let(:block) { ->(_) { { 1 => true } } }
 
-      let(:lazy_obj1) { BulkLoader::Lazy.new(1) }
-      let(:lazy_obj2) { BulkLoader::Lazy.new(1) }
+      let(:lazy_obj1) { BulkLoader::Lazy.new(1, name: :obj1) }
+      let(:lazy_obj2) { BulkLoader::Lazy.new(1, name: :obj2) }
 
       before do
         lazy_obj1.set(false)


### PR DESCRIPTION

```ruby
class YourModel
  include BulkLoader::DSL
  bulk_loader :name, :mapped_key, default: nil, autoload: false do |mapped_keys|
    # something with mapped_keys
  end
end
```

```ruby
  YourModel.new.name #=> raise error BulkLoader::UnloadAccessError
```

You can pass this by calling load explicitly.

```ruby
  model = YourModel.new
  YourModel.bulk_loader.load(:name, [model])
  model.name #=> it does not raise BulkLoader::UnloadAccessError
```